### PR TITLE
updated cmake version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@
 # to the cmake call.
 
 # Version 2.8.3 introduces CMakeParseArguments.
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 # Respect the PATH environment variable when searching for compilers.
 find_program(CMAKE_C_COMPILER NAMES $ENV{CC} gcc PATHS ENV PATH NO_DEFAULT_PATH)

--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT FAST_DOWNWARD_MAIN_CMAKELISTS_READ)
     message(


### PR DESCRIPTION
I was unable to install `alfworld` via `pip` due to a build failure in the `downward-textworld` dependency. The issue stems from an outdated `CMakeLists.txt` in `downward-textworld`, which specifies:

```cmake
cmake_minimum_required(VERSION 2.8.3)
```

This is incompatible with modern CMake versions (≥ 3.5), which have dropped support for legacy compatibility. Even with Anaconda and a properly configured environment, the install failed during the build step.

To fix this, I cloned the `downward` repository from [[MarcCote/downward](https://github.com/MarcCote/downward/tree/api_for_textworld)](https://github.com/MarcCote/downward/tree/api_for_textworld), switched to the `api_for_textworld` branch, and manually updated the `CMakeLists.txt` to:

```cmake
cmake_minimum_required(VERSION 3.5)
```

After this change, I was able to successfully build and install `downward-textworld` locally using Conda and `pip install .`. As a result, I could then install `alfworld` without any issues.

This workaround demonstrates that `downward-textworld` can be built with a modern toolchain, and suggests that updating the minimum CMake version in the repository (or providing an updated PyPI package) would improve compatibility for other users.
