### PR TITLE
Improve CI. Support recent compiler

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,5 +1,5 @@
 ---
-name: macOS
+name: macOS - Tests
 
 on:
   push:
@@ -13,12 +13,13 @@ on:
 
 jobs:
   test:
-    name: Compile and test planner - ${{ matrix.os }} - Python ${{ matrix.python }}
+    name: "${{ matrix.os }} | py${{ matrix.python }}"
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15, macos-latest]
         python: ['3.9', '3.10', '3.12', '3.13']
     steps:
       - name: Clone repository

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,5 +1,5 @@
 ---
-name: Ubuntu
+name: Ubuntu - Tests
 
 on:
   push:
@@ -13,12 +13,13 @@ on:
 
 jobs:
   compile:
-    name: Compile and test planner - ${{ matrix.os }} - Python ${{ matrix.python }}
+    name: "${{ matrix.os }} | py${{ matrix.python }}"
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-latest]
         python: ['3.9', '3.10', '3.12', '3.13']
     steps:
       - name: Clone repository

--- a/src/search/ext/optional.hh
+++ b/src/search/ext/optional.hh
@@ -2253,12 +2253,10 @@ public:
   /// one.
   ///
   /// \group emplace
-  template <class... Args> T &emplace(Args &&... args) noexcept {
-    static_assert(std::is_constructible<T, Args &&...>::value,
-                  "T must be constructible with Args");
-
-    *this = nullopt;
-    this->construct(std::forward<Args>(args)...);
+  template <class U = T>
+  T &emplace(U &&u) noexcept {
+    static_assert(std::is_lvalue_reference<U>::value, "U must be an lvalue");
+    m_value = std::addressof(u);
     return value();
   }
 


### PR DESCRIPTION
This pull request updates CI workflow configurations and modifies the `emplace` method in the `optional.hh` header. The changes improve workflow clarity and flexibility, and refactor the `emplace` method for better type safety and usage.

**CI workflow improvements:**

* Updated job naming in `.github/workflows/mac.yml` and `.github/workflows/ubuntu.yml` to a more concise format, making matrix values clearer in job names. [[1]](diffhunk://#diff-38c2966d1144b82978ca2cfe7650879fb15bd6da5845a3c616e8d152b29317f1L16-R22) [[2]](diffhunk://#diff-6640e8c668a6deeb426558faaa2b0f535d95814c09a05c044a1df27a008dd544L16-R22)
* Added `macos-latest` and `ubuntu-latest` to the test matrix, and removed older Ubuntu versions to keep the matrix current. [[1]](diffhunk://#diff-38c2966d1144b82978ca2cfe7650879fb15bd6da5845a3c616e8d152b29317f1L16-R22) [[2]](diffhunk://#diff-6640e8c668a6deeb426558faaa2b0f535d95814c09a05c044a1df27a008dd544L16-R22)
* Set `fail-fast: false` in both workflows to allow all matrix jobs to complete, even if one fails. [[1]](diffhunk://#diff-38c2966d1144b82978ca2cfe7650879fb15bd6da5845a3c616e8d152b29317f1L16-R22) [[2]](diffhunk://#diff-6640e8c668a6deeb426558faaa2b0f535d95814c09a05c044a1df27a008dd544L16-R22)
* Updated the workflow name in `.github/workflows/ubuntu.yml` for clarity.

**Codebase refactoring:**

* Refactored the `emplace` method in `src/search/ext/optional.hh` to accept only lvalue references and assign the address directly, improving type safety and usage clarity.